### PR TITLE
Expose endpoint for getting competition admins

### DIFF
--- a/resources/public/openapi/spec.yml
+++ b/resources/public/openapi/spec.yml
@@ -451,6 +451,27 @@ paths:
           description: User is not a competition admin.
         404:
           description: Match does not exist.
+    delete:
+      tags: [match]
+      summary: Remove the match referee
+      description: >
+        Delete the referee of the given match. The user making the request must
+        be authenticated as a competition admin.
+      parameters:
+        - in: path
+          name: match
+          schema:
+            type: integer
+          description: The match ID.
+      responses:
+        204:
+          description: Referee removed.
+        403:
+          description: User is not a competition admin.
+        404:
+          description: >
+            Either the match does not exist or the match does not have a
+            referee.
 
 components:
   securitySchemes:

--- a/resources/public/openapi/spec.yml
+++ b/resources/public/openapi/spec.yml
@@ -9,6 +9,8 @@ info:
     url: https://www.eclipse.org/legal/epl-2.0/
 
 tags:
+   - name: admin
+     description: Operations related to administration
    - name: auth
      description: Operations related to authentication and authorization
    - name: competition
@@ -23,7 +25,6 @@ tags:
      description: Operations related to teams
    - name: user
      description: Operations related to users
-
 
 servers:
   - url: http://localhost/api
@@ -233,6 +234,28 @@ paths:
                 $ref: '#/components/schemas/Team'
         404:
           description: The team does not exist.
+
+  /competition/{competition}/admins:
+    get:
+      tags: [competition admin]
+      summary: Get competition admins.
+      parameters:
+        - in: path
+          name: competition
+          description: The ID of the competition.
+          required: true
+          schema:
+            type: integer
+            example: 2
+      responses:
+        200:
+          description: Successfully retrieved admins.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompetitionAdmins'
+        404:
+          description: The competition does not exist.
 
   /competitions/{competition}/teams:
     get:
@@ -491,6 +514,22 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Competition'
+
+    CompetitionAdmin:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        alias:
+          type: string
+          readOnly: true
+          example: Kalle
+
+    CompetitionAdmins:
+      type: array
+      items:
+        $ref: '#/components/schemas/CompetitionAdmin'
 
     Set:
       type: object

--- a/resources/public/openapi/spec.yml
+++ b/resources/public/openapi/spec.yml
@@ -540,9 +540,11 @@ components:
       type: object
       properties:
         id:
+          description: The user ID of the admin.
           type: integer
           example: 1
         alias:
+          description: The user alias of the admin.
           type: string
           readOnly: true
           example: Kalle

--- a/src/amazestats/database/match.clj
+++ b/src/amazestats/database/match.clj
@@ -36,7 +36,7 @@
            matches))
     (catch org.postgresql.util.PSQLException e (log/error e))))
 
-(defn set-match-referee
+(defn set-match-referee!
   "Updates a `match` with a new team as referee.
   Will return the updated column and value as a map if successful, otherwise
   nil."

--- a/src/amazestats/handlers/competition.clj
+++ b/src/amazestats/handlers/competition.clj
@@ -1,6 +1,7 @@
 (ns amazestats.handlers.competition
   (:require [amazestats.database.competition :as db]
-            [amazestats.util.response :refer [internal-error not-found ok]]))
+            [amazestats.util.response :refer [internal-error not-found ok]]
+            [clojure.set :as set]))
 
 (defn get-all-competitions
   "Create a response map containing all competitions.
@@ -21,3 +22,17 @@
     (if (nil? competition)
       (not-found "Competition does not exist.")
       (ok {:competition competition}))))
+
+(defn get-competition-admins
+  "Create a response with all admins for a competition with given `id`.
+  Returns a 404 if the competition does not exist, otherwise a map containing
+  the `id` and `alias` for all admins in the competition."
+  [competition-id]
+  (let [competition-id (Integer. competition-id)
+        admins (db/get-competition-admins competition-id)]
+    (if (and (empty? admins) (nil? (db/get-competition-by-id competition-id)))
+      (not-found "Competition does not exist.")
+      (let [admins (map (fn [admin]
+                          (set/rename-keys admin {:admin :id}))
+                        admins)]
+        (ok {:admins admins})))))

--- a/src/amazestats/handlers/match.clj
+++ b/src/amazestats/handlers/match.clj
@@ -25,7 +25,7 @@
       (not-found "Season does not exist.")
       (ok {:matches matches}))))
 
-(defn update-match-referee
+(defn update-match-referee!
   "Updates the given `match`'s referee.
   The user updating the referee must be authenticated as a competition
   administrator, otherwise a 403 will be returned. On success, the updated
@@ -45,7 +45,7 @@
              "The user must be a competition admin to update referees."}) 
 
           (let [referee (Integer. (get-in request [:body :id]))
-                referee-map (db/set-match-referee (:id match) referee)]
+                referee-map (db/set-match-referee! (:id match) referee)]
             (if (nil? referee-map)
               (bad-request "Could not appoint team as referee.")
               (ok referee-map))))))))
@@ -69,7 +69,7 @@
             (forbidden
               {:message
                "The user must be a competition admin to update referees."})
-            (let [referee (db/set-match-referee (:id match) nil)]
+            (let [referee (db/set-match-referee! (:id match) nil)]
               (if (nil? referee)
                 (internal-error)
                 (no-content)))))))))

--- a/src/amazestats/routes.clj
+++ b/src/amazestats/routes.clj
@@ -16,6 +16,7 @@
             [amazestats.authentication :as auth]
             [amazestats.handlers :refer [get-token]]
             [amazestats.handlers.competition :refer [get-all-competitions
+                                                     get-competition-admins
                                                      get-competition-by-id]]
             [amazestats.handlers.division :refer [create-division!
                                                   find-divisions-by-competition
@@ -71,7 +72,9 @@
            (GET "/:competition/divisions" [competition]
                 (find-divisions-by-competition competition))
            (GET "/:competition/teams" [competition]
-                (find-teams-by-competition competition)))
+                (find-teams-by-competition competition))
+           (GET "/:competition/admins" [competition]
+                (get-competition-admins competition)))
 
   (context "/api/divisions" []
            (GET "/" [key] (if (nil? key)

--- a/src/amazestats/routes.clj
+++ b/src/amazestats/routes.clj
@@ -2,6 +2,7 @@
   (:require [buddy.auth.middleware :refer [wrap-authentication]]
             [compojure.core :refer [context
                                     defroutes
+                                    DELETE
                                     GET
                                     POST
                                     PUT
@@ -25,7 +26,8 @@
                                                   get-all-divisions]]
             [amazestats.handlers.match :refer [find-matches-by-season
                                                get-match-by-id
-                                               update-match-referee]]
+                                               update-match-referee
+                                               remove-match-referee!]]
             [amazestats.handlers.season :refer [find-seasons-by-division
                                                 get-season-by-id]]
             [amazestats.handlers.team :refer [create-team!
@@ -57,7 +59,8 @@
     (context "/competitions/:competition/divisions" [competition]
       (POST "/" request (create-division! competition request)))
     (context "/matches/:match" [match]
-             (PUT "/referee" request (update-match-referee match request)))))
+             (PUT "/referee" request (update-match-referee match request))
+             (DELETE "/referee" request (remove-match-referee! match request)))))
 
 
 ;;; PUBLIC ROUTES

--- a/src/amazestats/routes.clj
+++ b/src/amazestats/routes.clj
@@ -26,7 +26,7 @@
                                                   get-all-divisions]]
             [amazestats.handlers.match :refer [find-matches-by-season
                                                get-match-by-id
-                                               update-match-referee
+                                               update-match-referee!
                                                remove-match-referee!]]
             [amazestats.handlers.season :refer [find-seasons-by-division
                                                 get-season-by-id]]
@@ -59,7 +59,7 @@
     (context "/competitions/:competition/divisions" [competition]
       (POST "/" request (create-division! competition request)))
     (context "/matches/:match" [match]
-             (PUT "/referee" request (update-match-referee match request))
+             (PUT "/referee" request (update-match-referee! match request))
              (DELETE "/referee" request (remove-match-referee! match request)))))
 
 

--- a/src/amazestats/util/response.clj
+++ b/src/amazestats/util/response.clj
@@ -14,6 +14,11 @@
   {:status 201
    :headers {"Location" location-uri}})
 
+(defn no-content
+  []
+  {:status 204
+   :headers {}})
+
 
 ;;; Client Errors
 

--- a/test/amazestats/handlers/competition_test.clj
+++ b/test/amazestats/handlers/competition_test.clj
@@ -50,3 +50,38 @@
              {:status 404
               :headers {}
               :body {:message "Competition does not exist."}})))))
+
+(deftest get-competition-admins-test
+
+  (testing "200 Get admins OK"
+    (with-redefs [db/get-competition-admins (fn [_] '({:admin 1
+                                                       :alias "Ken"}
+                                                      {:admin 2
+                                                       :alias "Barbie"}))]
+      (is (= (get-competition-admins "1")
+             {:status 200
+              :headers {}
+              :body {:admins '({:id 1
+                                :alias "Ken"}
+                               {:id 2
+                                :alias "Barbie"})}}))))
+
+
+  (testing "404 Competition does not exist"
+    (with-redefs [db/get-competition-admins (fn [_] '())
+                  db/get-competition-by-id (fn [_] nil)]
+      (is (= (get-competition-admins "1")
+             {:status 404
+              :headers {}
+              :body {:message "Competition does not exist."}}))))
+
+  (testing "200 Empty list of admins"
+    (with-redefs [db/get-competition-admins (fn [_] '())
+                  db/get-competition-by-id (fn [_] {:id 1
+                                                    :key "korpen"
+                                                    :name "Korpen V"})]
+      (is (= (get-competition-admins "1")
+             {:status 200
+              :headers {}
+              :body {:admins '()}})))))
+  

--- a/test/amazestats/handlers/match_test.clj
+++ b/test/amazestats/handlers/match_test.clj
@@ -61,11 +61,11 @@
 (deftest update-match-referee-test
 
   (testing "404 The match does not exist"
-    (with-redefs [db/set-match-referee (fn [_ _r] nil)
+    (with-redefs [db/set-match-referee! (fn [_ _r] nil)
                   db/get-competition-id-for-match (fn [_] 17)
                   db/get-match-by-id (fn [_] nil)
                   competition-db/competition-admin? (fn [_c _u] true)]
-      (is (= (update-match-referee "20" {:identity {:user-id 5}
+      (is (= (update-match-referee! "20" {:identity {:user-id 5}
                                          :body {:id "17"}})
              {:status 404
               :headers {}
@@ -75,7 +75,7 @@
     (with-redefs [competition-db/competition-admin? (fn [_c _u] false)
                   db/get-match-by-id (fn [_] {:id 20})
                   db/get-competition-id-for-match (fn [_] 17)]
-      (is (= (update-match-referee "20" {:identity {:user-id 5}
+      (is (= (update-match-referee! "20" {:identity {:user-id 5}
                                          :body {:id "17"}})
              {:status 403
               :headers {}
@@ -84,22 +84,22 @@
                "The user must be a competition admin to update referees."}}))))
 
   (testing "400 The given referee does not match a team id"
-    (with-redefs [db/set-match-referee (fn [_ _r] nil)
+    (with-redefs [db/set-match-referee! (fn [_ _r] nil)
                   db/get-competition-id-for-match (fn [_] 17)
                   db/get-match-by-id (fn [_] {:id 20})
                   competition-db/competition-admin? (fn [_c _u] true)]
-      (is (= (update-match-referee "20" {:identity {:user-id 6}
+      (is (= (update-match-referee! "20" {:identity {:user-id 6}
                                          :body {:id "17"}})
              {:status 400
               :headers {}
               :body {:message "Could not appoint team as referee."}}))))
 
   (testing "200 The updated resource is returned"
-    (with-redefs [db/set-match-referee (fn [_ r] {:referee r})
+    (with-redefs [db/set-match-referee! (fn [_ r] {:referee r})
                   db/get-match-by-id (fn [_] {:id 20})
                   db/get-competition-id-for-match (fn [_] 17)
                   competition-db/competition-admin? (fn [_c _u] true)]
-      (is (= (update-match-referee "20" {:identity {:user-id 5}
+      (is (= (update-match-referee! "20" {:identity {:user-id 5}
                                          :body {:id "17"}})
              {:status 200
               :headers {}
@@ -108,7 +108,7 @@
 (deftest remove-match-referee-test
 
   (testing "204 Referee removed"
-    (with-redefs [db/set-match-referee (fn [_ r] {:referee r})
+    (with-redefs [db/set-match-referee! (fn [_ r] {:referee r})
                   db/get-match-by-id (fn [id] {:id id :referee 7})
                   db/get-competition-id-for-match (fn [_] 17)
                   competition-db/competition-admin? (fn [_c _u] true)]
@@ -142,7 +142,7 @@
               :body {:message "The match does not have a referee."}}))))
 
   (testing "500 Error occurred in the database"
-    (with-redefs [db/set-match-referee (fn [_ _r] nil)
+    (with-redefs [db/set-match-referee! (fn [_ _r] nil)
                   db/get-match-by-id (fn [id] {:id id :referee 7})
                   db/get-competition-id-for-match (fn [_] 17)
                   competition-db/competition-admin? (fn [_c _u] true)]

--- a/test/amazestats/handlers/match_test.clj
+++ b/test/amazestats/handlers/match_test.clj
@@ -95,7 +95,7 @@
               :body {:message "Could not appoint team as referee."}}))))
 
   (testing "200 The updated resource is returned"
-    (with-redefs [db/set-match-referee (fn [_ ref] {:id ref})
+    (with-redefs [db/set-match-referee (fn [_ r] {:referee r})
                   db/get-match-by-id (fn [_] {:id 20})
                   db/get-competition-id-for-match (fn [_] 17)
                   competition-db/competition-admin? (fn [_c _u] true)]
@@ -103,4 +103,4 @@
                                          :body {:id "17"}})
              {:status 200
               :headers {}
-              :body {:id 17}})))))
+              :body {:referee 17}})))))


### PR DESCRIPTION
Further additions to the same resource will be the ability to post and
delete admins for competitions.