### PR TITLE
Bugfix/complete migrations on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ The same commands could be ran by:
 ```bash
 make deploy server-logs
 ```
+
+### Migrations
+
+See [Migrations](resources/sql/migrations/README.md).

--- a/resources/sql/migrations/README.md
+++ b/resources/sql/migrations/README.md
@@ -1,0 +1,39 @@
+# Migrations
+
+In this directory the initialization script (*init.sql*) and all migrations
+are stored.
+Creating, marking and running these migrations are done via
+`src/amazestats/database/migration.clj`.
+
+## Application Usage
+
+The application will run the `init.sql` script the first time the application
+is started (or if the database is not initialized).
+During this first time all migrations will also be marked as complete,
+as the init-script should be complete.
+
+The next server starts will check for new migrations and run them if available.
+
+## Creating Migration
+
+Run `amazestats/database/migration/create`.
+This will result in newly generated, time-stamped migration scripts
+(up and down).
+Give the script a proper description after the time stamp.
+
+**NOTE:** Scripts that should run multiple statements should have the
+statements separated by `--;;`.
+
+## Migration and Rollback
+
+To run the migrations or to roll them back use the functions:
+`amazestats/database/migration/migrate` and
+`amazestats/database/migration/rollback`.
+
+## Marking as Completed
+
+The migrations could be marked as completed without being ran with:
+`amazestats/database/migration/mark-all-migrations-complete` or
+`amazestats/database/migration/mark-complete` (for single migration).
+
+For most users this should not be relevant.

--- a/src/amazestats/database/migration.clj
+++ b/src/amazestats/database/migration.clj
@@ -1,6 +1,9 @@
 (ns amazestats.database.migration
   (:require [amazestats.database.core :refer [db-spec]]
-            [migratus.core :as migratus]))
+            [clojure.tools.logging :as log]
+            [migratus.core :as migratus]
+            [migratus.database :as migratus-db]
+            [migratus.protocols :as proto]))
 
 (def config {:store                 :database
              :migration-dir         "sql/migrations/"
@@ -8,11 +11,49 @@
              :migration-table-name  "migrations"
              :db                    db-spec})
 
-(defn init
+(defn mark-complete
+  "Mark a `migration` as completed."
+  [migration]
+  (log/info "Marking:" (proto/id migration))
+  (let [db (:db config)
+        table-name (migratus-db/migration-table-name config)
+        migration-name (:name migration)
+        migration-id (proto/id migration)]
+    (migratus-db/mark-complete db table-name migration-name migration-id)))
+
+(defn mark-all-migrations-complete
+  "Marks all migrations as completed without running them."
   []
-  (migratus/init config))
+  (let [store (proto/make-store config)]
+    (try
+      (proto/connect store)
+      (let [migrations (->> (migratus/uncompleted-migrations config store)
+                            (sort-by proto/id))]
+        (when (seq migrations)
+          (loop [[migration & more] migrations]
+            (when migration
+              (mark-complete migration)
+              (recur more)))))
+
+      (catch Exception e
+        (log/error "Error occurred during migration marking:" e))
+      (finally (proto/disconnect store)))))
+
+(defn create-migration-table
+  "Create the migration table."
+  []
+  (proto/connect (proto/make-store config)))
+
+(defn init
+  "Initializes the database and marks all migrations as completed."
+  []
+  (migratus/init config)
+  (create-migration-table)
+  (log/info "Marking migrations as complete during initialization.")
+  (mark-all-migrations-complete))
 
 (defn migrate
+  "Run uncompleted migrations."
   []
   (migratus/migrate config))
 
@@ -21,6 +62,8 @@
   (migratus/rollback config))
 
 (defn create
+  "Create new migration.
+  The migration will be created in the migration directory."
   []
   (migratus/create config))
               


### PR DESCRIPTION
@hansenemily 
This should solve your issues. You could either drop your database and re-run the initialization or you could run the migration functions to mark scripts as completed on your own. The latter alternative should allow you to keep data you have.